### PR TITLE
use $ prefix for tutor completer since it's private

### DIFF
--- a/inst/lib/tutor/tutor.js
+++ b/inst/lib/tutor/tutor.js
@@ -6,7 +6,7 @@ $(document).ready(function() {
 
   // register autocompletion if available
   if (typeof TutorCompleter !== "undefined")
-    tutor.completer = new TutorCompleter(tutor);
+    tutor.$completer = new TutorCompleter(tutor);
 
   window.tutor = tutor;
 });


### PR DESCRIPTION
@kevinushey It seems like this variable isn't referenced anywhere so this is the only change necessary, let me know if there is anything I missed.

I prefixed with `$` because `Tutor` actually exposes a public API and I wanted that bit to be private.