### PR TITLE
rename exercise_skipped to section_skipped

### DIFF
--- a/R/events.R
+++ b/R/events.R
@@ -48,20 +48,23 @@ question_submission_event <- function(session,
 }
 
 
-exercise_skipped_event <- function(session, label) {
+section_skipped_event <- function(session, sectionId) {
+  
+  # event data
+  event_data <- list(sectionId = sectionId)
   
   # notify server-side listeners
   record_event(session = session,
-               event = "exercise_skipped",
-               data = list(label = label))
+               event = "section_skipped",
+               data = event_data)
   
   # notify client side listeners
   broadcast_progress_event_to_client(session = session, 
-                                     event = "exercise_skipped",
-                                     data = list(label = label))
+                                     event = "section_skipped",
+                                     data = event_data)
   
   # save for later replay
-  save_exercise_skipped(session = session, label = label)
+  save_section_skipped(session = session, sectionId = sectionId)
 }
 
 exercise_submission_event <- function(session,

--- a/R/http-handlers.R
+++ b/R/http-handlers.R
@@ -105,13 +105,13 @@ register_http_handlers <- function(session, metadata) {
   }))
   
   # exercise skipped event
-  session$registerDataObj("exercise_skipped", NULL, rpc_handler(function(input) {
+  session$registerDataObj("section_skipped", NULL, rpc_handler(function(input) {
     
     # extract inputs
-    label <- input$label
+    sectionId <- input$sectionId
     
     # fire event
-    exercise_skipped_event(session = session, label = label)
+    section_skipped_event(session = session, sectionId = sectionId)
     
   }))
   

--- a/R/storage.R
+++ b/R/storage.R
@@ -39,11 +39,12 @@ save_exercise_submission <- function(session, label, code, output, error_message
   )  
 }
 
-save_exercise_skipped <- function(session, label) {
+
+save_section_skipped <- function(session, sectionId) {
   save_object(
     session = session,
-    object_id = label,
-    tutor_object("exercise_skipped", list())
+    object_id = ns_wrap("section_skipped", sectionId),
+    tutor_object("section_skipped", list())
   )
 }
 
@@ -112,8 +113,8 @@ video_progress_from_state_objects <- function(state_objects) {
   filter_state_objects(state_objects, c("video_progress"))
 }
 
-exercise_skipped_progress_from_state_objects <- function(state_objects) {
-  filter_state_objects(state_objects, c("exercise_skipped"))
+section_skipped_progress_from_state_objects <- function(state_objects) {
+  filter_state_objects(state_objects, c("section_skipped"))
 }
 
 
@@ -139,15 +140,15 @@ progress_events_from_state_objects <- function(state_objects) {
          ))
   })
   
-  # now exercises skipped
-  exercise_skipped_progress <- exercise_skipped_progress_from_state_objects(state_objects)
-  exercise_skipped_progress_events <- lapply(exercise_skipped_progress, function(skipped) {
-    list(event = "exercise_skipped",
+  # now sections skipped
+  section_skipped_progress <- section_skipped_progress_from_state_objects(state_objects)
+  section_skipped_progress_events <- lapply(section_skipped_progress, function(skipped) {
+    list(event = "section_skipped",
          data = list(
-           label = skipped$id
+           sectionId = ns_unwrap("section_skipped", skipped$id)
          ))
   })
-  progress_events <- append(progress_events, exercise_skipped_progress_events)
+  progress_events <- append(progress_events, section_skipped_progress_events)
   
   # now video_progress
   video_progress <- video_progress_from_state_objects(state_objects)
@@ -210,6 +211,14 @@ tutor_object <- function(type, data) {
     type = type,
     data = data
   )
+}
+
+ns_wrap <- function(ns, id) {
+  paste0(ns, id)
+}
+
+ns_unwrap <- function(ns, id) {
+  substring(id, nchar(ns) + 1)
 }
 
 

--- a/inst/lib/tutor/tutor.js
+++ b/inst/lib/tutor/tutor.js
@@ -40,9 +40,9 @@ function Tutor() {
     });
   };
   
-  // API: Skip an exercise
-  this.skipExercise = function(label) {
-    thiz.$serverRequest("exercise_skipped", { label: label }, null);
+  // API: Skip a section
+  this.skipSection = function(sectionId) {
+    thiz.$serverRequest("section_skipped", { sectionId: sectionId }, null);
   };
   
   // API: scroll an element into view
@@ -183,8 +183,8 @@ Tutor.prototype.$fireProgressEvent = function(event, data) {
     }
     
   }
-  else if (event == "exercise_skipped") {
-     var exerciseElement = $('.tutor-exercise[data-label="' + data.label + '"]');
+  else if (event == "section_skipped") {
+     var exerciseElement = $('#' + data.sectionId);
      progressEvent.element = exerciseElement;
      progressEvent.completed = false;
   }
@@ -228,8 +228,8 @@ Tutor.prototype.$initializeProgress = function(progress_events) {
       progressEventData.label = progress.data.label;
       progressEventData.correct = progress.data.correct;
     }
-    else if (progressEvent == "exercise_skipped") {
-      progressEventData.label = progress.data.label;
+    else if (progressEvent == "section_skipped") {
+      progressEventData.sectionId = progress.data.sectionId;
       progressEventData.correct = false;
     }
     else if (progressEvent == "video_progress") {

--- a/inst/rmarkdown/templates/tutorial/resources/tutorial-format.js
+++ b/inst/rmarkdown/templates/tutorial/resources/tutorial-format.js
@@ -150,14 +150,14 @@ $(document).ready(function() {
         else {
           scrollLastSectionToView = true;
         }
-        tutor.skipExercise(sectionId);
+        tutor.skipSection(sectionId);
       }
     }
 
     function handleNextTopicClick(event) {
       // any sections in this topic? if not, mark it as skipped
       if (topics[currentTopicIndex].sections.length == 0) {
-        tutor.skipExercise(topics[currentTopicIndex].id);
+        tutor.skipSection(topics[currentTopicIndex].id);
       }
       updateLocation(currentTopicIndex + 1);
     }
@@ -447,8 +447,8 @@ $(document).ready(function() {
     tutor.onProgress(function(progressEvent) {
       if (progressEvent.event === "section_completed")
         sectionCompleted(progressEvent.element);
-      else if (progressEvent.event === "exercise_skipped")
-        exerciseSkipped($(progressEvent.element));
+      else if (progressEvent.event === "section_skipped")
+        sectionCompleted(progressEvent.element);
     });
 
   });

--- a/inst/rmarkdown/templates/tutorial/resources/tutorial-format.js
+++ b/inst/rmarkdown/templates/tutorial/resources/tutorial-format.js
@@ -400,27 +400,25 @@ $(document).ready(function() {
   }
 
   // update the UI after a section or topic (with 0 sections) gets skipped
-  function exerciseSkipped(exerciseElement) {
-    var sectionSkippedLabel;
+  function sectionSkipped(exerciseElement) {
+    var sectionSkippedId;
     if (exerciseElement.length) {
-      console.log('something changed in tutor ...');
-      return;
-    //  sectionSkippedLabel = exerciseElement.attr('data-label');
+      sectionSkippedId = exerciseElement[0].id;
     }
-    else {  // fish out the id of the section that got skipped skipped
-      sectionSkippedLabel = $(exerciseElement).selector.split('"')[1];
+    else {  // error
+      console.log('section' + $(exerciseElement).selector.split('"')[1] +'not found')
     }
 
 
     var topicIndex = -1;
     $.each(topics, function( ti, topic) {
-      if (sectionSkippedLabel == topic.id) {
+      if (sectionSkippedId == topic.id) {
         topicIndex = ti;
         topic.topicCompleted = true;
         return false;
       }
       $.each(topic.sections, function( si, section) {
-        if (sectionSkippedLabel == section.id) {
+        if (sectionSkippedId == section.id) {
           topicIndex = ti;
           section.skipped = true;
           topic.sectionsSkipped++;
@@ -448,7 +446,7 @@ $(document).ready(function() {
       if (progressEvent.event === "section_completed")
         sectionCompleted(progressEvent.element);
       else if (progressEvent.event === "section_skipped")
-        sectionCompleted(progressEvent.element);
+        sectionSkipped(progressEvent.element);
     });
 
   });


### PR DESCRIPTION
Addresses #44 

@robbyshaver This PR renames the exercise_skipped event to section_skipped. As part of the change your `exerciseSkipped` helper function is no longer called (both `section_completed` and `section_skipped` both call `sectionCompleted`): 

https://github.com/rstudio/tutor/blob/feature/section-skipped/inst/rmarkdown/templates/tutorial/resources/tutorial-format.js#L446-L453

Not sure if this is the right change and/or if other refinements are required. Could you try out this PR locally and let me know if everything is working as you expect and whether we need additional refinement?
